### PR TITLE
add exhibit relationship counts and find resources without an exhibit

### DIFF
--- a/scripts/exhibit_service.rb
+++ b/scripts/exhibit_service.rb
@@ -11,6 +11,35 @@ class ExhibitService
     def services
       puts 'database_entries'
       puts '  # @param [Integer] exhibit id'
+      puts 'counts'
+      puts '  # @param [Integer] exhibit id'
+    end
+
+    # @param [Integer] exhibit id
+    def counts(id)
+      puts "====================================================="
+      begin
+        exhibit = Spotlight::Exhibit.find(id)
+        puts "Database entries related to exhibit #{id} -- title: #{exhibit.title}   slug: #{exhibit.slug}   featured_image: #{exhibit.featured_image}   masthead: #{exhibit.masthead_id}   thumbnail: #{exhibit.thumbnail_id}"
+      rescue ActiveRecord::RecordNotFound => e
+        puts "EXHIBIT DOES NOT EXIST: #{id}"
+        puts "Looking for related database entries that may be hanging around"
+      end
+      puts "====================================================="
+      count_resources(id)
+      count_solr_document_sidecars(id)
+      count_searches(id)
+      count_filters(id)
+      count_main_navigations(id)
+      count_pages(id)
+      count_attachments(id)
+      count_blacklight_configurations(id)
+      count_contact_emails(id)
+      count_contacts(id)
+      count_custom_fields(id)
+      count_reindexing_log_entries(id)
+      count_slugs(id)
+      puts "====================================================="
     end
 
     # @param [Integer] exhibit id
@@ -36,9 +65,14 @@ class ExhibitService
       list_contacts(id)
       list_custom_fields(id)
       list_reindexing_log_entries(id)
+      list_slugs(id)
     end
 
     private
+
+      def count_attachments exhibit_id
+        puts "Attachments: #{Spotlight::Attachment.where(exhibit_id: exhibit_id).count}"
+      end
 
       def list_attachments exhibit_id
         puts 'Attachments:'
@@ -46,6 +80,10 @@ class ExhibitService
           puts "  exhibit: #{r.exhibit_id}   id: #{r.id}   file: #{r.file}"
         end
         puts '------------'
+      end
+
+      def count_blacklight_configurations exhibit_id
+        puts "Blacklight Configurations: #{Spotlight::BlacklightConfiguration.where(exhibit_id: exhibit_id).count}"
       end
 
       def list_blacklight_configurations exhibit_id
@@ -56,12 +94,20 @@ class ExhibitService
         puts '------------'
       end
 
+      def count_contact_emails exhibit_id
+        puts "Contact Emails: #{Spotlight::ContactEmail.where(exhibit_id: exhibit_id).count}"
+      end
+
       def list_contact_emails exhibit_id
         puts 'Contact Emails:'
         Spotlight::ContactEmail.where(exhibit_id: exhibit_id).each do |r|
           puts "  exhibit: #{r.exhibit_id}   id: #{r.id}   email: #{r.email}"
         end
         puts '------------'
+      end
+
+      def count_contacts exhibit_id
+        puts "Contacts: #{Spotlight::Contact.where(exhibit_id: exhibit_id).count}"
       end
 
       def list_contacts exhibit_id
@@ -72,12 +118,20 @@ class ExhibitService
         puts '------------'
       end
 
+      def count_custom_fields exhibit_id
+        puts "Custom Fields: #{Spotlight::CustomField.where(exhibit_id: exhibit_id).count}"
+      end
+
       def list_custom_fields exhibit_id
         puts 'Custom Fields:'
         Spotlight::CustomField.where(exhibit_id: exhibit_id).each do |r|
           puts "  exhibit: #{r.exhibit_id}   id: #{r.id}   field: #{r.field}"
         end
         puts '------------'
+      end
+
+      def count_filters exhibit_id
+        puts "Filters: #{Spotlight::Filter.where(exhibit_id: exhibit_id).count}"
       end
 
       def list_filters exhibit_id
@@ -88,12 +142,20 @@ class ExhibitService
         puts '------------'
       end
 
+      def count_main_navigations exhibit_id
+        puts "Main Navigation: #{Spotlight::MainNavigation.where(exhibit_id: exhibit_id).count}"
+      end
+
       def list_main_navigations exhibit_id
         puts 'Main Navigation:'
         Spotlight::MainNavigation.where(exhibit_id: exhibit_id).each do |r|
           puts "  exhibit: #{r.exhibit_id}   id: #{r.id}   label: #{r.label}   nav_type: #{r.nav_type}"
         end
         puts '------------'
+      end
+
+      def count_pages exhibit_id
+        puts "Pages: #{Spotlight::Page.where(exhibit_id: exhibit_id).count}"
       end
 
       def list_pages exhibit_id
@@ -104,12 +166,20 @@ class ExhibitService
         puts '------------'
       end
 
+      def count_reindexing_log_entries exhibit_id
+        puts "Reindexing Log Entries: #{Spotlight::ReindexingLogEntry.where(exhibit_id: exhibit_id).count}"
+      end
+
       def list_reindexing_log_entries exhibit_id
         puts 'Reindexing Log Entries:'
         Spotlight::ReindexingLogEntry.where(exhibit_id: exhibit_id).each do |r|
           puts "  exhibit: #{r.exhibit_id}   id: #{r.id}   start_time: #{r.start_time}   end_time: #{r.end_time}"
         end
         puts '------------'
+      end
+
+      def count_resources exhibit_id
+        puts "Resources: #{Spotlight::Resource.where(exhibit_id: exhibit_id).count}"
       end
 
       def list_resources exhibit_id
@@ -127,12 +197,20 @@ class ExhibitService
         puts '------------'
       end
 
+      def count_searches exhibit_id
+        puts "Searches: #{Spotlight::Search.where(exhibit_id: exhibit_id).count}"
+      end
+
       def list_searches exhibit_id
         puts 'Searches:'
         Spotlight::Search.where(exhibit_id: exhibit_id).each do |r|
           puts "  exhibit: #{r.exhibit_id}   id: #{r.id}   title: #{r.title}   published: #{r.published}   featured_item: #{r.featured_item_id}   masthead: #{r.masthead_id}   thumbnail: #{r.thumbnail_id}"
         end
         puts '------------'
+      end
+
+      def count_solr_document_sidecars exhibit_id
+        puts "Solr Document Sidecars: #{Spotlight::SolrDocumentSidecar.where(exhibit_id: exhibit_id).count}"
       end
 
       def list_solr_document_sidecars exhibit_id
@@ -144,6 +222,18 @@ class ExhibitService
               puts "     ALT SIDECAR: exhibit: #{alt_r.exhibit_id}   id: #{alt_r.id}   public: #{alt_r.public}   document: #{alt_r.document_id}   document_type: #{alt_r.document_type}   resource: #{alt_r.resource_id}   resource_type: #{alt_r.resource_type}" unless alt_r.id == r.id
             end
           end
+        end
+        puts '------------'
+      end
+
+      def count_slugs exhibit_id
+        puts "Friendly ID Slugs: #{FriendlyId::Slug.where(scope: "exhibit_id:#{exhibit_id}").count}"
+      end
+
+      def list_slugs exhibit_id
+        puts 'Friendly ID Slugs:'
+        FriendlyId::Slug.where(scope: "exhibit_id:#{exhibit_id}").each do |slug|
+          puts "  exhibit: #{slug.scope}   id: #{slug.id}   slug: #{slug.slug}   type: #{slug.sluggable_type}"
         end
         puts '------------'
       end


### PR DESCRIPTION
Adds…
* `ExhibitsService.count(id)`
* `ResourceDeleteService.find_resources_without_an_exhibit`

Counts…
* resources
* solr_document_sidecars
* searches
* filters
* main_navigations
* pages
* attachments
* blacklight_configurations
* contact_emails
* contacts
* custom_fields
* reindexing_log_entries
* slugs