### PR TITLE
allow exhibits to be limited to published exhibits only

### DIFF
--- a/scripts/data_studio.rb
+++ b/scripts/data_studio.rb
@@ -14,7 +14,7 @@ class DataStudio
   #   * click ADD A FIELD
   #   * set Field Name to Exhibits
   #   * set Formula to the results of this method
-  def self.exhibits_field
+  def self.exhibits_field(published: true)
     instructions = <<-INSTRUCTIONS
 # To setup the field in datastudio:
 #   * click any widget that uses data
@@ -26,7 +26,7 @@ class DataStudio
 
     INSTRUCTIONS
 
-    exhibits = Spotlight::Exhibit.all
+    exhibits = published ? Spotlight::Exhibit.where(published: true) : Spotlight::Exhibit.all
 
     field = <<-FIELD
 CASE


### PR DESCRIPTION
The site dashboard really only wants to report on public use of the site which means public exhibits only.  The exhibits_field by defailt will only include published exhibits and gather the rest under Unpublished group.